### PR TITLE
Fix CCL support for 1.7.2+

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -1,3 +1,4 @@
+using System;
 using HarmonyLib;
 using UnityModManagerNet;
 
@@ -23,7 +24,8 @@ namespace DvMod.Mph
             if (value)
             {
                 harmony.PatchAll();
-                if (UnityModManager.FindMod("DVCustomCarLoader")?.Loaded ?? false)
+                UnityModManager.ModEntry ccl = UnityModManager.FindMod("DVCustomCarLoader");
+                if ((ccl?.Loaded ?? false) && ccl.Version >= Version.Parse("1.7.2"))
                     Mph.Speedometers.ModifyCustomCarPrefabs();
             }
             else

--- a/Mph.cs
+++ b/Mph.cs
@@ -73,7 +73,7 @@ namespace DvMod.Mph
             {
                 foreach (var relay in car.InteriorPrefab.GetComponentsInChildren<IndicatorRelay>())
                 {
-                    if (relay.EventType == SimEventType.Speed)
+                    if (relay.EventBinding == SimEventType.Speed)
                     {
                         Main.DebugLog($"Adjusting speedometer for {car.identifier}");
                         relay.Indicator.maxValue *= Constants.KmPerMile;


### PR DESCRIPTION
IndicatorRelay's EventType was renamed to EventBinding in https://github.com/katycat5e/DVCustomCarLoader/commit/496b2c36fca7cd6825582acdd34e1d721328eb93